### PR TITLE
Updated to React 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "^4.0.3"
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Resolved the error "0308010c:digital envelope routines::unsupported" seen after final pipeline build of the tutorial.